### PR TITLE
Fixed issue: TypeError: 'Logger' object is not callable

### DIFF
--- a/nmv/interface/ui/about/ops.py
+++ b/nmv/interface/ui/about/ops.py
@@ -47,7 +47,7 @@ class NMV_Update(bpy.types.Operator):
             return {'FINISHED'}
 
         if 'posix' in os.name:
-            nmv.logger('Updating NeuroMorphoVis on a unix-based OS')
+            nmv.logger.log('Updating NeuroMorphoVis on a unix-based OS')
         else:
             self.report({'ERROR'}, 'Cannot update NeuroMorphoVis on Windows! '
                                    'Please download the latest version from the GitHub '


### PR DESCRIPTION
Fixing an issue which must be a typo.  This change fixes an error 
"TypeError: 'Logger' object is not callable"
Indeed Logger should be called by the .log method, as in the rest of the code-base.

Platform: Ubuntu 22.04LTS, Blender 3.5.1

